### PR TITLE
Update api_reference.md to document the available printSize event

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -490,7 +490,7 @@ this.trigger("limit", [20]);
 
 - `printSize` (Looker 26.0+)
 
-	Allows visualizations to take advantage of the "Expand tables to show all rows" option when rendering dashboards to PDF. Using this event allows the application to know how tall the rendered content is and can expand the dashboard tile appropriatley so all the information is visible for printing.
+	Allows visualizations to take advantage of the "Expand tables to show all rows" option when rendering dashboards to PDF. Using this event allows the application to know how tall the rendered content is and can expand the dashboard tile appropriately so all the information is visible for printing.
 
 	```
 	  this.trigger('printSize', {

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -492,11 +492,11 @@ this.trigger("limit", [20]);
 
 	Allows visualizations to take advantage of the "Expand tables to show all rows" option when rendering dashboards to PDF. Using this event allows the application to know how tall the rendered content is and can expand the dashboard tile appropriately so all the information is visible for printing.
 
-	```
+	```js
 	  this.trigger('printSize', {
-        heightExpanded: FULL_HEIGHT_IN_PIXELS
+	    heightExpanded: FULL_HEIGHT_IN_PIXELS
 	  });
- 	```
+	```
 
 - `registerOptions` (Looker 5.24+)
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -488,6 +488,16 @@ this.trigger("limit", [20]);
 
 	Mark the visualization as no longer loading.
 
+- `printSize` (Looker 26.0+)
+
+	Allows visualizations to take advantage of the "Expand tables to show all rows" option when rendering dashboards to PDF. Using this event allows the application to know how tall the rendered content is and can expand the dashboard tile appropriatley so all the information is visible for printing.
+
+	```
+	  this.trigger('printSize', {
+        heightExpanded: FULL_HEIGHT_IN_PIXELS
+	  });
+ 	```
+
 - `registerOptions` (Looker 5.24+)
 
 	Allows visualizations to register additional options after the visualization has been registered:


### PR DESCRIPTION
This PR documents internal changes in looker for version 26.0 where we can allow custom visualizations to expand when printing to PDF.