### PR TITLE
docs: add async rendering and done callback examples to getting started guide

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -159,6 +159,12 @@ We can just modify the beginning of our `updateAsync` method to detect an error 
       return;
     }
 
+    if (!data || data.length === 0) {
+      this.addError({title: "No Data", message: "The query returned no results."});
+      done();
+      return;
+    }
+
     // ... the rest of the update code here ...
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -158,6 +158,8 @@ We can just modify the beginning of our `updateAsync` method to detect an error 
       done();
       return;
     }
+
+    // ... the rest of the update code here ...
 ```
 
 That's it! If the user creates a query that only has measures, they'll now see this:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -154,15 +154,71 @@ We can just modify the beginning of our `updateAsync` method to detect an error 
     // Throw some errors and exit if the shape of the data isn't what this chart needs.
     if (queryResponse.fields.dimensions.length == 0) {
       this.addError({title: "No Dimensions", message: "This chart requires dimensions."});
+      // Always call done() before exiting early to avoid dashboard exports hanging
+      done();
       return;
     }
-
-    // ... the rest of the update code here ...
 ```
 
 That's it! If the user creates a query that only has measures, they'll now see this:
 
 ![](../src/examples/hello_world/hello_world_error.png)
+
+
+### Asynchronous Rendering & PDF Exports
+
+In the "Hello World" example above, we called `done()` immediately after updating the DOM. This is perfectly safe because setting `innerHTML` is **synchronous**. 
+
+However, if you are using charting libraries like D3.js, Chart.js, or React, your rendering is likely **asynchronous**. If you call `done()` at the bottom of your script, Looker might capture the screenshot for a PDF or PNG export *before* your chart finishes drawing, resulting in a blank tile.
+
+When Looker exports a dashboard, it uses a headless browser and relies entirely on the `done()` callback to know when it is safe to take a screenshot. 
+
+To ensure your charts export perfectly, you must tie the `done()` callback to your library's native completion event, and disable animations during exports using the `details.print` flag.
+
+Here is an example of how to handle asynchronous rendering using D3.js:
+
+```js
+  updateAsync: function(data, element, config, queryResponse, details, done) {
+    this.clearErrors();
+    
+    // Check if Looker is exporting the chart to a PDF/PNG
+    const isExport = details && details.print === true;
+
+    // Clear previous elements
+    this.svg.selectAll("*").remove();
+    
+    const circle = this.svg.append("circle")
+      .attr("cx", 50)
+      .attr("cy", 50);
+
+    if (isExport) {
+      // Instant render for exports. Draw the final state immediately with no transitions
+      circle.attr("r", 40);
+      
+      // Tell Looker to take the screenshot right now
+      done(); 
+    } else {
+      // If it's for the browser, start small and animate
+      circle.attr("r", 0)
+        .transition()
+        .duration(1000)
+        .attr("r", 40)
+        .on("end", () => {
+           // Tell Looker the animation is fully complete
+           done(); 
+        });
+    }
+  }
+  ```
+
+  If you are using React, ensure you pass the done callback as the third argument to your render function so Looker waits for React to mount the components:
+  ``` js
+    this.chart = ReactDOM.render(
+      <MyCustomChart data={data} />,
+      element,
+      done // Looker waits for React to finish
+    );
+  ```
 
 ### Configuration
 

--- a/src/examples/hello_world/hello_world.js
+++ b/src/examples/hello_world/hello_world.js
@@ -8,17 +8,13 @@ looker.plugins.visualizations.add({
     font_size: {
       type: "string",
       label: "Font Size",
-      values: [
-        {"Large": "large"},
-        {"Small": "small"}
-      ],
+      values: [{ Large: "large" }, { Small: "small" }],
       display: "radio",
-      default: "large"
-    }
+      default: "large",
+    },
   },
   // Set up the initial state of the visualization
-  create: function(element, config) {
-
+  create: function (element, config) {
     // Insert a <style> tag with some styles we'll use later.
     element.innerHTML = `
       <style>
@@ -45,23 +41,27 @@ looker.plugins.visualizations.add({
 
     // Create an element to contain the text.
     this._textElement = container.appendChild(document.createElement("div"));
-
   },
   // Render in response to the data or settings changing
-  updateAsync: function(data, element, config, queryResponse, details, done) {
-
+  updateAsync: function (data, element, config, queryResponse, details, done) {
     // Clear any errors from previous updates
     this.clearErrors();
 
     // Throw some errors and exit if the shape of the data isn't what this chart needs
-    if (queryResponse.fields.dimensions.length == 0) {
-      this.addError({title: "No Dimensions", message: "This chart requires dimensions."});
+    if (!data || data.length === 0) {
+      this.addError({
+        title: "No Data",
+        message: "The query returned no results.",
+      });
       done();
       return;
     }
 
-    if (!data || data.length === 0) {
-      this.addError({title: "No Data", message: "The query returned no results."});
+    if (queryResponse.fields.dimensions.length == 0) {
+      this.addError({
+        title: "No Dimensions",
+        message: "This chart requires dimensions.",
+      });
       done();
       return;
     }
@@ -81,6 +81,6 @@ looker.plugins.visualizations.add({
     }
 
     // We are done rendering! Let Looker know.
-    done()
-  }
+    done();
+  },
 });

--- a/src/examples/hello_world/hello_world.js
+++ b/src/examples/hello_world/hello_world.js
@@ -60,6 +60,12 @@ looker.plugins.visualizations.add({
       return;
     }
 
+    if (!data || data.length === 0) {
+      this.addError({title: "No Data", message: "The query returned no results."});
+      done();
+      return;
+    }
+
     // Grab the first cell of the data
     var firstRow = data[0];
     var firstCell = firstRow[queryResponse.fields.dimensions[0].name];

--- a/src/examples/hello_world/hello_world.js
+++ b/src/examples/hello_world/hello_world.js
@@ -56,6 +56,7 @@ looker.plugins.visualizations.add({
     // Throw some errors and exit if the shape of the data isn't what this chart needs
     if (queryResponse.fields.dimensions.length == 0) {
       this.addError({title: "No Dimensions", message: "This chart requires dimensions."});
+      done();
       return;
     }
 

--- a/src/examples/hello_world/hello_world_d3.js
+++ b/src/examples/hello_world/hello_world_d3.js
@@ -73,7 +73,6 @@ looker.plugins.visualizations.add({
       .attr("cy", height / 2)
       .attr("fill", config.font_size === "small" ? "#88C8F3" : "#008CD4"); // Using config just as a demo
 
-    // --- The `done()` Callback Logic ---
     if (isExport) {
       // INSTANT RENDER FOR PDF EXPORTS
       // Draw the final state immediately with no transitions.

--- a/src/examples/hello_world/hello_world_d3.js
+++ b/src/examples/hello_world/hello_world_d3.js
@@ -25,6 +25,14 @@ looker.plugins.visualizations.add({
   updateAsync: function (data, element, config, queryResponse, details, done) {
     // Clear any previous Looker errors
     this.clearErrors();
+    if (!data || data.length === 0) {
+      this.addError({
+        title: "No Data",
+        message: "The query returned no results.",
+      });
+      done();
+      return;
+    }
 
     if (
       queryResponse.fields.dimensions.length === 0 ||
@@ -35,15 +43,6 @@ looker.plugins.visualizations.add({
         message: "This chart requires at least one dimension and one measure.",
       });
       done(); // Call done() before early return
-      return;
-    }
-
-    if (!data || data.length === 0) {
-      this.addError({
-        title: "No Data",
-        message: "The query returned no results.",
-      });
-      done();
       return;
     }
 
@@ -59,7 +58,7 @@ looker.plugins.visualizations.add({
     // Grab the first measure value to determine the size of our visualization
     const firstRow = data[0];
     const measureName = queryResponse.fields.measures[0].name;
-    const measureValue = firstRow[measureName]?.value || 0;
+    const measureValue = Number(firstRow[measureName]?.value) || 0;
 
     // Create a circle in the center of the screen
     const targetRadius = Math.max(

--- a/src/examples/hello_world/hello_world_d3.js
+++ b/src/examples/hello_world/hello_world_d3.js
@@ -64,7 +64,7 @@ looker.plugins.visualizations.add({
     // Create a circle in the center of the screen
     const targetRadius = Math.max(
       0,
-      Math.min(measureValue || 0, Math.min(width, height) / 2 - 10),
+      Math.min(measureValue, Math.min(width, height) / 2 - 10),
     );
 
     const circle = this.svg

--- a/src/examples/hello_world/hello_world_d3.js
+++ b/src/examples/hello_world/hello_world_d3.js
@@ -1,0 +1,80 @@
+// Note: This assumes d3 is imported or available in your visualization environment
+looker.plugins.visualizations.add({
+  options: {
+    font_size: {
+      type: "string",
+      label: "Font Size",
+      values: [
+        {"Large": "large"},
+        {"Small": "small"}
+      ],
+      display: "radio",
+      default: "large"
+    }
+  },
+
+  create: function(element, config) {
+    // Clear Looker's default element container
+    element.innerHTML = "";
+
+    // Set up our persistent D3 SVG canvas
+    this.svg = d3.select(element).append("svg")
+      .attr("width", "100%")
+      .attr("height", "100%");
+  },
+
+  updateAsync: function(data, element, config, queryResponse, details, done) {
+    // Clear any previous Looker errors
+    this.clearErrors();
+
+    if (queryResponse.fields.dimensions.length === 0 || queryResponse.fields.measures.length === 0) {
+      this.addError({title: "Missing Data", message: "This chart requires at least one dimension and one measure."});
+      done(); // Call done() before early return
+      return;
+    }
+
+    // --- Setup ---
+    // Check if this is a headless browser export (PDF/PNG)
+    const isExport = details && details.print === true;
+
+    // Clear previous D3 elements before redrawing
+    this.svg.selectAll("*").remove();
+
+    const width = element.clientWidth;
+    const height = element.clientHeight;
+
+    // Grab the first measure value to determine the size of our visualization
+    const firstRow = data[0];
+    const measureName = queryResponse.fields.measures[0].name;
+    const measureValue = firstRow[measureName].value;
+
+    // Create a circle in the center of the screen
+    const targetRadius = Math.min(measureValue, Math.min(width, height) / 2 - 10);
+    
+    const circle = this.svg.append("circle")
+      .attr("cx", width / 2)
+      .attr("cy", height / 2)
+      .attr("fill", config.font_size === "small" ? "#88C8F3" : "#008CD4"); // Using config just as a demo
+
+    // --- The `done()` Callback Logic ---
+    if (isExport) {
+      // INSTANT RENDER FOR PDF EXPORTS
+      // Draw the final state immediately with no transitions.
+      circle.attr("r", targetRadius);
+      
+      // Tell Looker to take the screenshot right now.
+      done(); 
+    } else {
+      // ANIMATED RENDER FOR BROWSER
+      // Start with a radius of 0 and transition to the target radius
+      circle.attr("r", 0)
+        .transition()
+        .duration(1000) // 1 second animation
+        .attr("r", targetRadius)
+        .on("end", () => {
+           // Tell Looker the animation is finished
+           done(); 
+        });
+    }
+  }
+});

--- a/src/examples/hello_world/hello_world_d3.js
+++ b/src/examples/hello_world/hello_world_d3.js
@@ -59,7 +59,7 @@ looker.plugins.visualizations.add({
     // Grab the first measure value to determine the size of our visualization
     const firstRow = data[0];
     const measureName = queryResponse.fields.measures[0].name;
-    const measureValue = firstRow[measureName].value;
+    const measureValue = firstRow[measureName].value ? firstRow[measureName].value : 0;
 
     // Create a circle in the center of the screen
     const targetRadius = Math.max(

--- a/src/examples/hello_world/hello_world_d3.js
+++ b/src/examples/hello_world/hello_world_d3.js
@@ -4,36 +4,49 @@ looker.plugins.visualizations.add({
     font_size: {
       type: "string",
       label: "Font Size",
-      values: [
-        {"Large": "large"},
-        {"Small": "small"}
-      ],
+      values: [{ Large: "large" }, { Small: "small" }],
       display: "radio",
-      default: "large"
-    }
+      default: "large",
+    },
   },
 
-  create: function(element, config) {
+  create: function (element, config) {
     // Clear Looker's default element container
     element.innerHTML = "";
 
     // Set up our persistent D3 SVG canvas
-    this.svg = d3.select(element).append("svg")
+    this.svg = d3
+      .select(element)
+      .append("svg")
       .attr("width", "100%")
       .attr("height", "100%");
   },
 
-  updateAsync: function(data, element, config, queryResponse, details, done) {
+  updateAsync: function (data, element, config, queryResponse, details, done) {
     // Clear any previous Looker errors
     this.clearErrors();
 
-    if (queryResponse.fields.dimensions.length === 0 || queryResponse.fields.measures.length === 0) {
-      this.addError({title: "Missing Data", message: "This chart requires at least one dimension and one measure."});
+    if (
+      queryResponse.fields.dimensions.length === 0 ||
+      queryResponse.fields.measures.length === 0
+    ) {
+      this.addError({
+        title: "Missing Data",
+        message: "This chart requires at least one dimension and one measure.",
+      });
       done(); // Call done() before early return
       return;
     }
 
-    // --- Setup ---
+    if (!data || data.length === 0) {
+      this.addError({
+        title: "No Data",
+        message: "The query returned no results.",
+      });
+      done();
+      return;
+    }
+
     // Check if this is a headless browser export (PDF/PNG)
     const isExport = details && details.print === true;
 
@@ -49,9 +62,13 @@ looker.plugins.visualizations.add({
     const measureValue = firstRow[measureName].value;
 
     // Create a circle in the center of the screen
-    const targetRadius = Math.min(measureValue, Math.min(width, height) / 2 - 10);
-    
-    const circle = this.svg.append("circle")
+    const targetRadius = Math.max(
+      0,
+      Math.min(measureValue || 0, Math.min(width, height) / 2 - 10),
+    );
+
+    const circle = this.svg
+      .append("circle")
       .attr("cx", width / 2)
       .attr("cy", height / 2)
       .attr("fill", config.font_size === "small" ? "#88C8F3" : "#008CD4"); // Using config just as a demo
@@ -61,20 +78,21 @@ looker.plugins.visualizations.add({
       // INSTANT RENDER FOR PDF EXPORTS
       // Draw the final state immediately with no transitions.
       circle.attr("r", targetRadius);
-      
+
       // Tell Looker to take the screenshot right now.
-      done(); 
+      done();
     } else {
       // ANIMATED RENDER FOR BROWSER
       // Start with a radius of 0 and transition to the target radius
-      circle.attr("r", 0)
+      circle
+        .attr("r", 0)
         .transition()
         .duration(1000) // 1 second animation
         .attr("r", targetRadius)
         .on("end", () => {
-           // Tell Looker the animation is finished
-           done(); 
+          // Tell Looker the animation is finished
+          done();
         });
     }
-  }
+  },
 });

--- a/src/examples/hello_world/hello_world_d3.js
+++ b/src/examples/hello_world/hello_world_d3.js
@@ -59,7 +59,7 @@ looker.plugins.visualizations.add({
     // Grab the first measure value to determine the size of our visualization
     const firstRow = data[0];
     const measureName = queryResponse.fields.measures[0].name;
-    const measureValue = firstRow[measureName].value ? firstRow[measureName].value : 0;
+    const measureValue = firstRow[measureName]?.value || 0;
 
     // Create a circle in the center of the screen
     const targetRadius = Math.max(

--- a/src/examples/hello_world_react/hello_world_react.js
+++ b/src/examples/hello_world_react/hello_world_react.js
@@ -1,6 +1,6 @@
-import Hello from './hello'
-import React from 'react'
-import ReactDOM from 'react-dom'
+import Hello from "./hello";
+import React from "react";
+import ReactDOM from "react-dom";
 
 looker.plugins.visualizations.add({
   // Id and Label are legacy properties that no longer have any function besides documenting
@@ -12,17 +12,13 @@ looker.plugins.visualizations.add({
     font_size: {
       type: "string",
       label: "Font Size",
-      values: [
-        {"Large": "large"},
-        {"Small": "small"}
-      ],
+      values: [{ Large: "large" }, { Small: "small" }],
       display: "radio",
-      default: "large"
-    }
+      default: "large",
+    },
   },
   // Set up the initial state of the visualization
-  create: function(element, config) {
-
+  create: function (element, config) {
     // Insert a <style> tag with some styles we'll use later.
     element.innerHTML = `
       <style>
@@ -52,20 +48,30 @@ looker.plugins.visualizations.add({
 
     // Render to the target element
     this.chart = ReactDOM.render(
-      <Hello data="loading..."/>,
-      this._textElement
+      <Hello data="loading..." />,
+      this._textElement,
     );
-
   },
   // Render in response to the data or settings changing
-  updateAsync: function(data, element, config, queryResponse, details, done) {
-
+  updateAsync: function (data, element, config, queryResponse, details, done) {
     // Clear any errors from previous updates
     this.clearErrors();
 
     // Throw some errors and exit if the shape of the data isn't what this chart needs
     if (queryResponse.fields.dimensions.length == 0) {
-      this.addError({title: "No Dimensions", message: "This chart requires dimensions."});
+      this.addError({
+        title: "No Dimensions",
+        message: "This chart requires dimensions.",
+      });
+      done();
+      return;
+    }
+
+    if (!data || data.length === 0) {
+      this.addError({
+        title: "No Data",
+        message: "The query returned no results.",
+      });
       done();
       return;
     }
@@ -83,10 +89,9 @@ looker.plugins.visualizations.add({
 
     // Finally update the state with our new data
     this.chart = ReactDOM.render(
-      <Hello data={firstCell}/>,
+      <Hello data={firstCell} />,
       this._textElement,
-      done
+      done,
     );
-
-  }
+  },
 });

--- a/src/examples/hello_world_react/hello_world_react.js
+++ b/src/examples/hello_world_react/hello_world_react.js
@@ -58,19 +58,19 @@ looker.plugins.visualizations.add({
     this.clearErrors();
 
     // Throw some errors and exit if the shape of the data isn't what this chart needs
-    if (queryResponse.fields.dimensions.length == 0) {
+    if (!data || data.length === 0) {
       this.addError({
-        title: "No Dimensions",
-        message: "This chart requires dimensions.",
+        title: "No Data",
+        message: "The query returned no results.",
       });
       done();
       return;
     }
 
-    if (!data || data.length === 0) {
+    if (queryResponse.fields.dimensions.length == 0) {
       this.addError({
-        title: "No Data",
-        message: "The query returned no results.",
+        title: "No Dimensions",
+        message: "This chart requires dimensions.",
       });
       done();
       return;

--- a/src/examples/hello_world_react/hello_world_react.js
+++ b/src/examples/hello_world_react/hello_world_react.js
@@ -66,6 +66,7 @@ looker.plugins.visualizations.add({
     // Throw some errors and exit if the shape of the data isn't what this chart needs
     if (queryResponse.fields.dimensions.length == 0) {
       this.addError({title: "No Dimensions", message: "This chart requires dimensions."});
+      done();
       return;
     }
 
@@ -83,10 +84,9 @@ looker.plugins.visualizations.add({
     // Finally update the state with our new data
     this.chart = ReactDOM.render(
       <Hello data={firstCell}/>,
-      this._textElement
+      this._textElement,
+      done
     );
 
-    // We are done rendering! Let Looker know.
-    done()
   }
 });


### PR DESCRIPTION
Updates getting_started.md to provide clear guidance on handling the done() callback, specifically addressing the common issue of blank tiles in PDF/PNG dashboard exports. 

Additions include:
- A fix to the "Handling Errors" example to ensure done() is called before early returns, preventing export timeouts.
- A new "Asynchronous Rendering & PDF Exports" section explaining how the Looker headless browser evaluates render timing.
- Practical code snippets for D3.js to ensure accurate screenshots.